### PR TITLE
Added reset for non collected items counts every credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Program rom patches for Battle Garegga that add some convenience and functionali
  - No rank carry over between credits. Rank starts at power on default
    every credit.
  - Item drop order reset to initial value every credit
+ - Item non collected counts reset to initial values every credit
  - Quick reset: start+ABC resets to the copyright screen
  - Scoreboard display bug fixed. Top scores will show the proper letter
    instead of punctuation for 10M+

--- a/patch.s
+++ b/patch.s
@@ -22,7 +22,10 @@ FREE_OFFSET = $52430
 
 	ORG $9A2 
 	dc.w $F0BB
-
+; Reset passed items count
+	ORG $B86
+	clr.l ($109CB8) ; reset $109CB8 count (unknown and already present in code), small shot count ($109CB9 already present in code), small bomb count ($109CBA) and option count ($109CBB)
+	clr.b ($109CBC) ; reset medal count ($109CBC)
 ; Reset item drop state
 	ORG $BEE
 	clr.b ($109CB4) ; re-initialize enemy kill count for item drop


### PR DESCRIPTION
There are 4 bytes in memory where item non collected counts are stored. They are important to activate special option formations.
In original code, not all of these counts are reset in every credit (only small shot item is), so previous credit state of non collected items affects the new one.

- $109CB9 is the small shot items non collected count
- $109CBA is the small bomb items non collected count
- $109CBB is the option items non collected count
- $109CBC is the medal items non collected count

patch.s file is updated to reset all these counts in every credit.
Original code has these instructions:
- $B86:  clr.b $109CB8 ; reset unknown count
- $B8C:  clr.b $109CB9 ; reset small shot items count

it could be changed to:
- $B86:  clr.l $109CB8 ; reset unknown, small shot, small bomb and option items counts
- $B8C:  clr.b $109CBC ; reset medal items count


Only prg1.bin file is affected to these changes, but I did not udpate the related ips file for it (as I don't know how to achieve that ;P )

Thanks